### PR TITLE
Include binaryen optimization in `cargo screeps`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Unreleased
 ==================
 
+- Add configurable binaryen optimization pass, defaulting to minimal processing (#17)
 
 0.3.3 (2019-07-20)
 ==================

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ description = "Build tool for deploying Rust WASM code to Screeps game servers"
 
 [dependencies]
 base64 = "0.10"
+binaryen = "0.8"
 clap = "2"
 # We rely on the output format of cargo-web, which is not a publicly guaranteed property.
 cargo-web = "=0.6.26"

--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@ cargo-screeps
 
 Build tool for deploying Rust WASM repositories to [Screeps][screeps] game servers.
 
-`cargo-screeps` wraps [`cargo-web`], adding the ability to trim node.js and web javascript code from
-the output files, and allows uploading directly to Screeps servers.
+`cargo-screeps` wraps [`cargo-web`] and [`binaryen`], adding the ability to trim node.js and web
+javascript code from the output files, to run binaryen optimization automatically, and to upload
+directly to Screeps servers.
+
+### screeps-game-api
 
 The other main project in this organization is [`screeps-game-api`], type-safe bindings to the
 in-game Screeps API.
@@ -14,6 +17,19 @@ in-game Screeps API.
 These two tools go together well, but do not depend on eachother. `cargo-screeps` can compile and
 upload any screeps WASM project buildable with `stdweb`'s `cargo-web`, and `screeps-game-api` is
 usable in any project built with `cargo-web`.
+
+### cargo-web
+
+[`cargo-web`] is the base which `cargo-screeps` depends upon. It implements post-processing interop
+between Rust and JavaScript, and allows [`stdweb`] to function.
+
+### binaryen
+
+[Binaryen] is a set of tools for working with and optimizing WASM modules. cargo-screeps uses [rust
+bindings to binaryen][binaryen-rs] to run the `wasm-opt` optimization passes on all output files.
+
+Even with `optimization_level = 0` and `shrink_level = 0` (the default and lowest optimization
+settings), file size can be decreased by as much as 10%.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,21 @@ This configures general build options.
 - `output_wasm_file`: the WASM file to rename compile WASM to (default `"compiled.wasm"`)
 - `initialize_header_file`: a file containing the JavaScript for starting the WASM instance. See
   [overriding the default initialization header](#overriding-the-default-initialization-header)
+- `wasm_opt_binary`: the path to the `wasm-opt` binary from the [Binaryen] toolset (default
+  `"wasm-opt"`)
+
+  If set to a valid binary path, then `wasm-opt` will be used to optimize binaries after building.
+
+## `[build.binaryen]`
+
+This contains configuration options for the binaryen optimization pass.
+
+- `shrink_level`: How much to focus on shrinking code when running binaryen pass. Using 2+ is not
+  recommended (default 0)
+- `optimization_level`: How much to focus on making code fast when running binaryen pass. Use 1, 2,
+  3, or 4 for progressively slower builds and faster output (default 0)
+- `debug_info`: Whether to keep debug info in output wasm module. Currently not super useful since
+  builds produced by 'cargo' don't include debug info to begin with. (default `true`)
 
 ## Overriding the default initialization header
 
@@ -146,5 +161,8 @@ cargo screeps build
 [crate]: https://crates.io/crates/cargo-screeps/
 [`screeps-game-api`]: https://github.com/rustyscreeps/screeps-game-api/
 [`cargo-web`]: https://github.com/koute/cargo-web
+[`stdweb`]: https://github.com/koute/stdweb
 [screepsmod-auth]: https://www.npmjs.com/package/screepsmod-auth
 [screeps]: https://screeps.com/
+[Binaryen]: https://github.com/WebAssembly/binaryen
+[binaryen-rs]: https://github.com/pepyakin/binaryen-rs

--- a/screeps-defaults.toml
+++ b/screeps-defaults.toml
@@ -18,3 +18,8 @@ branch = "default"
 # use absolute file path to get out of "target/"
 # ouptut_js_file = "main.js"
 # output_wasm_file = "compiled.wasm"
+
+# [build.binaryen]
+# shrink_level = 0
+# optimization_level = 0
+# debug_info = true

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,38 @@ use log::*;
 use serde::Deserialize;
 
 #[derive(Clone, Debug, Deserialize)]
+pub struct BinaryenConfig {
+    #[serde(default = "BinaryenConfig::default_shrink_level")]
+    pub shrink_level: u32,
+    #[serde(default = "BinaryenConfig::default_optimization_level")]
+    pub optimization_level: u32,
+    #[serde(default = "BinaryenConfig::default_debug_info")]
+    pub debug_info: bool,
+}
+
+impl BinaryenConfig {
+    fn default_shrink_level() -> u32 {
+        0
+    }
+    fn default_optimization_level() -> u32 {
+        0
+    }
+    fn default_debug_info() -> bool {
+        true
+    }
+}
+
+impl Default for BinaryenConfig {
+    fn default() -> Self {
+        BinaryenConfig {
+            shrink_level: Self::default_shrink_level(),
+            optimization_level: Self::default_optimization_level(),
+            debug_info: Self::default_debug_info(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
 pub struct BuildConfiguration {
     #[serde(default = "BuildConfiguration::default_output_wasm_file")]
     pub output_wasm_file: PathBuf,
@@ -16,6 +48,8 @@ pub struct BuildConfiguration {
     pub output_js_file: PathBuf,
     #[serde(default)]
     pub initialization_header_file: Option<PathBuf>,
+    #[serde(default)]
+    pub binaryen: BinaryenConfig,
 }
 
 impl Default for BuildConfiguration {
@@ -24,6 +58,7 @@ impl Default for BuildConfiguration {
             output_wasm_file: Self::default_output_wasm_file(),
             output_js_file: Self::default_output_js_file(),
             initialization_header_file: None,
+            binaryen: BinaryenConfig::default(),
         }
     }
 }


### PR DESCRIPTION
This adds a dependency on the rust bindings for https://github.com/WebAssembly/binaryen, a wasm toolset.

The main tool I want to use here is [wasm-opt](https://github.com/WebAssembly/binaryen#wasm-opt), which can do a significant amount of optimization on compiled wasm files above what `cargo` does. With the default options, `-O0`, it reduces my crate's binary size from 3.3mb to 3mb. Probably just trimming unused code, but that's helpful?

We can also configure it to optimize more for size and/or speed, though. I'm sure some work will be duplicated between this and LLVM, but it can definitely reduce size further than LLVM alone, and that's pretty helpful for screeps.