### PR TITLE
Remove stack trace limit in default initialization header

### DIFF
--- a/docs/initialization-header.md
+++ b/docs/initialization-header.md
@@ -13,6 +13,10 @@ The default initialization header is as follows:
 // If `new WebAssembly.Instance` times out, this will helpfully remain here to be reused next tick.
 let wasm_module = null;
 
+// Allow stack traces to have infinite length. This is in here purely so that it's presence and/or
+// value can be configured. The default limit for the number of lines in a stack trace is 10.
+Error.stackTraceLimit = Infinity;
+
 // This function does the initialization. It's separate from `module.exports.loop` so JS code can
 // run `module.exports.loop = wasm_initialize` to reset the WASM vm next tick.
 function wasm_initialize() {

--- a/resources/default_initialization_header.js
+++ b/resources/default_initialization_header.js
@@ -1,6 +1,8 @@
 "use strict";
 let wasm_module = null;
 
+Error.stackTraceLimit = Infinity;
+
 function wasm_initialize() {
     
     if (Game.cpu.bucket < 500) {


### PR DESCRIPTION
Default node.js setting is to limit stack traces to 10 lines. I've found this can sometimes be useful, but some bugs just need more stack space.

This adds a setting to the default initialization header which disables that stack trace limit. I added it here because it's the sort of thing someone might want to configure, but is in general useful?

I found this solution of setting the limit to infinity at https://stackoverflow.com/a/10419288/1907543.

