### PR TITLE
Add optional wasm-opt pass post build.

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -89,7 +89,7 @@ pub fn build(root: &Path, config: &Configuration) -> Result<(), failure::Error> 
     fs::create_dir_all(&out_dir)?;
 
     let optimize_wasm = if config.build.optimize {
-        if Path::new("wasm-opt").is_file() {
+        if Path::new("wasm-opt").is_file() || Path::new("wasm-opt.exe").is_file()  {
             true
         } else {
             warn!("wasm-opt binary does not exist, skipping optimization");

--- a/src/build.rs
+++ b/src/build.rs
@@ -7,17 +7,23 @@ use structopt::StructOpt;
 
 use crate::config::{BuildConfiguration, Configuration};
 
-pub fn check(root: &Path) -> Result<(), failure::Error> {
+pub fn check(root: &Path, config: &Configuration) -> Result<(), failure::Error> {
     debug!("running check");
 
     debug!("changing directory to {}", root.display());
 
     env::set_current_dir(&root)?;
 
-    debug!("running cargo-web check --target=wasm32-unknown-unknown");
+    let mut args = vec!["--target=wasm32-unknown-unknown".to_owned()];
+
+    if let Some(default_package) = &config.package {
+        args.push(format!("--package={}", default_package));
+    }
+
+    debug!("running cargo-web check {}", args.join(" "));
 
     let res = cargo_web::run(CargoWebOpts::Check(
-        CheckOpts::from_iter_safe(&["--target=wasm32-unknown-unknown"])
+        CheckOpts::from_iter_safe(&args)
             .expect("expected hardcoded cargo-web args to be valid"),
     ));
     if let Err(e) = res {
@@ -35,10 +41,16 @@ pub fn build(root: &Path, config: &Configuration) -> Result<(), failure::Error> 
 
     env::set_current_dir(&root)?;
 
-    debug!("running cargo-web build --target=wasm32-unknown-unknown --release");
+    let mut args = vec!["--target=wasm32-unknown-unknown".to_owned(), "--release".to_owned()];
+
+    if let Some(default_package) = &config.package {
+        args.push(format!("--package={}", default_package));
+    }
+
+    debug!("running cargo-web build {}", args.join(" "));
 
     let res = cargo_web::run(CargoWebOpts::Build(
-        BuildOpts::from_iter_safe(&["--target=wasm32-unknown-unknown", "--release"])
+        BuildOpts::from_iter_safe(&args)
             .expect("expected hardcoded cargo-web args to be valid"),
     ));
     if let Err(e) = res {

--- a/src/build.rs
+++ b/src/build.rs
@@ -110,7 +110,15 @@ pub fn build(root: &Path, config: &Configuration) -> Result<(), failure::Error> 
             .arg(out_dir.join(&config.build.output_wasm_file))
             .output()?;
 
-        ensure!(output.status.success(), "error: wasm-opt finished with exit-code {}", output.status.code().map(|c| c.to_string()).unwrap_or("(none)".to_string()));
+        ensure!(
+            output.status.success(),
+            "error: wasm-opt finished with exit-code {}",
+            output
+                .status
+                .code()
+                .map(|c| c.to_string())
+                .unwrap_or("(none)".to_string())
+        );
 
         info!("optimized.");
     } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,6 +102,8 @@ pub enum DeployMode {
 struct FileConfiguration {
     default_deploy_mode: Option<DeployMode>,
     #[serde(default)]
+    package: Option<String>,
+    #[serde(default)]
     build: BuildConfiguration,
     upload: Option<FileUploadConfiguration>,
     copy: Option<CopyConfiguration>,
@@ -110,6 +112,7 @@ struct FileConfiguration {
 #[derive(Debug, Clone)]
 pub struct Configuration {
     pub default_deploy_mode: Option<DeployMode>,
+    pub package: Option<String>,
     pub build: BuildConfiguration,
     pub copy: Option<CopyConfiguration>,
     pub upload: Option<UploadConfiguration>,
@@ -157,6 +160,7 @@ impl Configuration {
     fn new(config: FileConfiguration) -> Result<Configuration, failure::Error> {
         Ok(Configuration {
             default_deploy_mode: config.default_deploy_mode,
+            package: config.package,
             build: config.build,
             upload: match config.upload {
                 Some(upload_config) => Some(UploadConfiguration::new(upload_config)?),

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,8 @@ pub struct BuildConfiguration {
     pub output_js_file: PathBuf,
     #[serde(default)]
     pub initialization_header_file: Option<PathBuf>,
+    #[serde(default)]
+    pub optimize: bool,
 }
 
 impl Default for BuildConfiguration {
@@ -24,6 +26,7 @@ impl Default for BuildConfiguration {
             output_wasm_file: Self::default_output_wasm_file(),
             output_js_file: Self::default_output_js_file(),
             initialization_header_file: None,
+            optimize: false
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,7 @@ impl Default for BuildConfiguration {
             output_wasm_file: Self::default_output_wasm_file(),
             output_js_file: Self::default_output_js_file(),
             initialization_header_file: None,
-            optimize: false
+            optimize: false,
         }
     }
 }

--- a/src/run.rs
+++ b/src/run.rs
@@ -26,7 +26,7 @@ pub fn run() -> Result<(), failure::Error> {
 
     match cli_config.command {
         setup::Command::Build => run_build(&root, &config)?,
-        setup::Command::Check => run_check(&root)?,
+        setup::Command::Check => run_check(&root, &config)?,
         setup::Command::Upload => {
             run_build(&root, &config)?;
             run_upload(&root, &config)?;
@@ -57,9 +57,9 @@ fn run_build(root: &Path, config: &Configuration) -> Result<(), failure::Error> 
     Ok(())
 }
 
-fn run_check(root: &Path) -> Result<(), failure::Error> {
+fn run_check(root: &Path, config: &Configuration) -> Result<(), failure::Error> {
     info!("checking...");
-    build::check(root)?;
+    build::check(root, config)?;
     info!("checked.");
 
     Ok(())


### PR DESCRIPTION
This adds an optional wasm-opt pass after building. It expects wasm-opt to be in the path. Adding an automatic download/install was too complex at this time to make worth adding the code for.