### PR TITLE
Allow specifying default package to build to support cargo workspaces.

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -7,17 +7,23 @@ use structopt::StructOpt;
 
 use crate::config::{BuildConfiguration, Configuration};
 
-pub fn check(root: &Path) -> Result<(), failure::Error> {
+pub fn check(root: &Path, config: &Configuration) -> Result<(), failure::Error> {
     debug!("running check");
 
     debug!("changing directory to {}", root.display());
 
     env::set_current_dir(&root)?;
 
-    debug!("running cargo-web check --target=wasm32-unknown-unknown");
+    let mut args = vec!["--target=wasm32-unknown-unknown".to_owned()];
+
+    if let Some(default_package) = &config.package {
+        args.push(format!("--package={}", default_package));
+    }
+
+    debug!("running cargo-web check {}", args.join(" "));
 
     let res = cargo_web::run(CargoWebOpts::Check(
-        CheckOpts::from_iter_safe(&["--target=wasm32-unknown-unknown"])
+        CheckOpts::from_iter_safe(&args)
             .expect("expected hardcoded cargo-web args to be valid"),
     ));
     if let Err(e) = res {
@@ -35,10 +41,16 @@ pub fn build(root: &Path, config: &Configuration) -> Result<(), failure::Error> 
 
     env::set_current_dir(&root)?;
 
-    debug!("running cargo-web build --target=wasm32-unknown-unknown --release");
+    let mut args = vec!["--target=wasm32-unknown-unknown".to_owned(), "--release".to_owned()];
+
+    if let Some(default_package) = &config.package {
+        args.push(format!("--package={}", default_package));
+    }
+
+    debug!("running cargo-web build {}", args.join(" "));
 
     let res = cargo_web::run(CargoWebOpts::Build(
-        BuildOpts::from_iter_safe(&["--target=wasm32-unknown-unknown", "--release"])
+        BuildOpts::from_iter_safe(&args)
             .expect("expected hardcoded cargo-web args to be valid"),
     ));
     if let Err(e) = res {

--- a/src/config.rs
+++ b/src/config.rs
@@ -99,6 +99,8 @@ pub enum DeployMode {
 struct FileConfiguration {
     default_deploy_mode: Option<DeployMode>,
     #[serde(default)]
+    package: Option<String>,
+    #[serde(default)]
     build: BuildConfiguration,
     upload: Option<FileUploadConfiguration>,
     copy: Option<CopyConfiguration>,
@@ -107,6 +109,7 @@ struct FileConfiguration {
 #[derive(Debug, Clone)]
 pub struct Configuration {
     pub default_deploy_mode: Option<DeployMode>,
+    pub package: Option<String>,
     pub build: BuildConfiguration,
     pub copy: Option<CopyConfiguration>,
     pub upload: Option<UploadConfiguration>,
@@ -154,6 +157,7 @@ impl Configuration {
     fn new(config: FileConfiguration) -> Result<Configuration, failure::Error> {
         Ok(Configuration {
             default_deploy_mode: config.default_deploy_mode,
+            package: config.package,
             build: config.build,
             upload: match config.upload {
                 Some(upload_config) => Some(UploadConfiguration::new(upload_config)?),

--- a/src/run.rs
+++ b/src/run.rs
@@ -26,7 +26,7 @@ pub fn run() -> Result<(), failure::Error> {
 
     match cli_config.command {
         setup::Command::Build => run_build(&root, &config)?,
-        setup::Command::Check => run_check(&root)?,
+        setup::Command::Check => run_check(&root, &config)?,
         setup::Command::Upload => {
             run_build(&root, &config)?;
             run_upload(&root, &config)?;
@@ -57,9 +57,9 @@ fn run_build(root: &Path, config: &Configuration) -> Result<(), failure::Error> 
     Ok(())
 }
 
-fn run_check(root: &Path) -> Result<(), failure::Error> {
+fn run_check(root: &Path, config: &Configuration) -> Result<(), failure::Error> {
     info!("checking...");
-    build::check(root)?;
+    build::check(root, config)?;
     info!("checked.");
 
     Ok(())


### PR DESCRIPTION
This is change allows specifying a package to build as part of the 'cargo web' parameters.

This change allows cargo workspaces to function by targeting a specific package to build and process by cargo web. Cargo web currently supports targeting a package with the '--package' argument, this can now be set from the screeps.toml.

An additional fix is needed in cargo-web to make workspaces fully functional but this change remains compatible even before that is integrated: https://github.com/koute/cargo-web/pull/246
