### PR TITLE
Allow additional named build 'modes', per-mode build options, and feature set support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Unreleased
 ==================
-
+- (Breaking) Remove `ptr` option from configuration, replaced with `prefix` which can be set to
+  a desired API URL prefix - `prefix = "ptr"` replaces the functionality of `ptr = true`
+- (Breaking) The default `port` is now 443 and `ssl` now defaults to true (previous default was
+  HTTPS for screeps.com and HTTP for other hosts)
+- `branch` option is no longer required, `"default"` is the default if none is configured
+- Options from the `[build]` section can be overridden for any individual mode in `[modename.build]`
+- `[build]` options now support specifying `features`, a list of crate features to be passed to
+  cargo-web
 
 0.3.3 (2019-07-20)
 ==================

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-screeps"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2018"
 authors = ["David Ross <daboross@daboross.net>"]
 documentation = "https://github.com/daboross/screeps-in-rust-via-wasm/cargo-screeps/"

--- a/README.md
+++ b/README.md
@@ -28,31 +28,6 @@ Configured in `[build]` config section. No required settings.
 3. appends initialization call using bytes from `require('<compiled module name>')`
 4. puts processed JS into `target/main.js` copy compiled WASM into `target/compiled.wasm`
 
-### `upload`:
-
-Requires `[upload]` config section with at minimum username, password and branch.
-
-1. runs build
-2. reads `target/*.js` and `target/*.wasm`, keeping track of filenames
-3. reads `screeps.toml` for upload options
-4. uploads all read files to server, using filenames as the filenames on the server
-
-### `copy`:
-
-Requires `[copy]` config section with at minimum destination and branch.
-
-1. runs build
-2. copies compiled main file and WASM file (default `main.js` and `compiled.wasm`) from `target/` to
-   `<destination directory>/<branch name>/`
-3. if pruning is enabled, deletes all other files in `<destination directory>/<branch name>/`
-
-### `deploy`:
-
-Requires `default_deploy_mode` configuration setting.
-
-1. runs build
-2. runs `upload` or `copy` depending on the `default_deploy_mode` configuration option
-
 ### `check`:
 
 Does not require configuration.
@@ -60,51 +35,41 @@ Does not require configuration.
 1. performs type checking and lifetime checking without compiling code
   - runs `cargo web check` (see `cargo check` for non-WASM codebases)
 
+### `deploy`:
+
+Runs the deployment mode specified by the `--mode` setting, or the `default_deploy_mode`
+configuration setting if none is specified.
+
+1. runs build
+2. depending on whether the mode uploads (has authentication credentials) or copies (has a
+   `destination`), proceeds to deploy the built code
+
+If copying:
+
+1. copies compiled main file and WASM file (default `main.js` and `compiled.wasm`) from `target/` to
+   `<destination directory>/<branch name>/`
+2. if pruning is enabled, deletes all other files in `<destination directory>/<branch name>/`
+
+If uploading:
+
+1. reads `target/*.js` and `target/*.wasm`, keeping track of filenames
+2. reads `screeps.toml` for upload options
+3. uploads all read files to server, using filenames as the filenames on the server
+
+### `upload`:
+
+A shortcut for `cargo screeps deploy -m upload`.
+
+### `copy`:
+
+A shortcut for `cargo screeps deploy -m copy`.
+
 # Configuration Options
 
 ## No namespace
 
-- `default_deploy_mode`: controls what `cargo screeps deploy` does
-
-  This configuration is required for `cargo screeps deploy`. Possible values are `"copy"`
-  and `"upload"`.
-
-## `[upload]`
-
-Options for the `upload` deploy mode.
-
-This section is required to use `cargo screeps upload`.
-
-- `auth_token`: an auth token for your Screeps account
-- `username`: your Screeps username or email
-- `password`: your Screeps password
-
-  Either an auth_token or your username/password can be supplied. When both are set the auth token is used. For private servers set a password using [screepsmod-auth].
-- `branch`: the branch on the server to upload files to
-- `ptr`: if true, upload to the "ptr" realm
-- `hostname`: the hostname to upload to
-
-  For example, this could be `screeps.com`, `localhost` or `server1.screepsplu.us`.
-- `ssl`: whether to connect to the server using ssl
-
-  This should generally be true for the main server and false for private servers.
-- `port`: port to connect to server with
-
-  This should generally be set to `21025` for private servers.
-
-## `[copy]`
-
-Options for the `copy` deploy mode.
-
-This section is required to use `cargo screeps copy`.
-
-- `destination`: the directory to copy files into
-
-  If this path is not absolute, it is interpreted as relative to `screeps.toml`
-- `branch`: the "branch" to copy into
-
-  This is the subdirectory of `destination` which the js/wasm files will be copied into.
-- `prune`: if true, extra files found in the destination/branch directory will be deleted
+- `default_deploy_mode`: controls what mode `cargo screeps deploy` uses if the `--mode`/`-m` option
+  is not set.
 
 ## `[build]`
 
@@ -115,8 +80,19 @@ This configures general build options.
 - `output_wasm_file`: the WASM file to rename compile WASM to (default `"compiled.wasm"`)
 - `initialize_header_file`: a file containing the JavaScript for starting the WASM instance. See
   [overriding the default initialization header](#overriding-the-default-initialization-header)
+- `features`: a list of crate features to be enabled during the build
 
-## Overriding the default initialization header
+Any of these options can be overridden for a given mode with its own build section. For instance,
+
+```
+[upload.build]
+features = ["alliance_behavior"]
+```
+
+would cause a feature on your crate named `alliance_behavior` to be built when running the `upload`
+mode.
+
+### Overriding the default initialization header
 
 `cargo-screeps` tries to make a reasonable `main.js` file to load the WASM. However, it's pretty
 basic, and you might find you want to do some things in JavaScript before loading the WASM module.
@@ -128,6 +104,52 @@ Two utility functions `wasm_fetch_module_bytes` and `wasm_create_stdweb_vars` wi
 created, but the initialization header controls what actually runs.
 
 See [docs/initialization-header.md] for more information on this.
+
+## Configuration modes
+
+Configuration modes can either copy the built files to a destination directory, or upload to a
+destination server using the Screeps API.
+
+A mode should either have a filesystem destination to copy to, or authentication credentials (and
+optionally, server information) to upload to.
+
+Optionally, it also have a sub-table `[mode.build]` to override any of the global `[build]` options.
+
+### Copy Options
+
+Options for deploying to a filesystem location.
+
+- `destination`: the directory to copy files into
+
+  If this path is not absolute, it is interpreted as relative to `screeps.toml`.
+- `branch`: the "branch" to copy into
+
+  This is the subdirectory of `destination` which the js/wasm files will be copied into. Default is `"default"`.
+- `prune`: if true, extra files found in the destination/branch directory will be deleted. Default is `false`.
+
+### Upload Options
+
+Options for deploying to a Screeps server.
+
+- `auth_token`: an auth token for your Screeps account
+- `username`: your Screeps username or email
+- `password`: your Screeps password
+
+  Either an auth_token or your username/password can be supplied. When both are set the auth token is used. For private servers set a password using [screepsmod-auth].
+- `branch`: the "branch" to copy into
+
+  This is the "branch" on the screeps server to deploy to. Default is `"default"`.
+- `prefix`: if set, adds a URL prefix to the upload path.  Use `"ptr"` or `"season"` to upload to
+  the public test realm and seasonal servers, respectively.
+- `hostname`: the hostname to upload to
+
+  For example, this could be `screeps.com`, `localhost` or `server1.screepsplu.us`. Default is `screeps.com`.
+- `ssl`: whether to connect to the server using ssl
+
+  This should generally be true for the main server and false for private servers. Default is `true`.
+- `port`: port to connect to server with
+
+  This should generally be set to `21025` for private servers. Default is `443`.
 
 # Updating `cargo screeps`
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -51,7 +51,6 @@ use_field_init_shorthand = false
 force_explicit_abi = true
 condense_wildcard_suffixes = false
 color = "Auto"
-required_version = "1.3.0"
 unstable_features = false
 disable_all_formatting = false
 skip_children = false

--- a/screeps-defaults.toml
+++ b/screeps-defaults.toml
@@ -31,7 +31,7 @@ auth_token = "your auth token"
 # branch = "default"
 # prune = false
 # # Override global build section items for any mode, if needed
-# [copy.build]
+#   [copy.build]
 #   features = ["private-server"]
 
 # [ptr]
@@ -41,5 +41,5 @@ auth_token = "your auth token"
 # [season]
 # auth_token = "your auth token"
 # prefix = "season"
-# [season.build]
+#   [season.build]
 #   features = ["my-crate-season-1-feature"]

--- a/screeps-defaults.toml
+++ b/screeps-defaults.toml
@@ -1,37 +1,45 @@
-default_deploy_target = "upload"
+default_deploy_mode = "upload"
 
 # [build]
-# use absolute file path to get out of "target/"
-# ouptut_js_file = "main.js"
+# # use absolute file path to get out of "target/"
+# output_js_file = "main.js"
 # output_wasm_file = "compiled.wasm"
 # features = []
 
-[targets.upload]
-mode = "upload"
-# either auth_token or username and password required for upload
+# Add any number of deployment modes below; when deploying, select which mode to use with
+# `cargo screeps deploy -m modename`
+# Each requires at least a destination (to deploy to a filesystem path), or authentication
+# credentials (to upload to a server via API), which can be either an auth_token or
+# username and password.
+
+[upload]
 auth_token = "your auth token"
 # username = "your username or email"
 # password = "your password"
+# # The following are the default values for the optional upload options, uncomment to change
 # branch = "default"
-# ptr = false
 # hostname = "screeps.com"
 # ssl = true
 # port = 443
+# # This option has no default - any string value will set a path prefix in the API URL,
+# # such as "ptr" and "season" to reach the APIs of those environments
+# prefix = "url_prefix"
 
-# [targets.ptr]
-# mode = "upload"
+# [copy]
+# destination = "your copy destination without the branch directory"
+# # The following are the default values for the optional copy options, uncomment to change
+# branch = "default"
+# prune = false
+# # Override global build section items for any mode, if needed
+# [copy.build]
+#   features = ["private-server"]
+
+# [ptr]
 # auth_token = "your auth token"
 # prefix = "ptr"
 
-# [targets.season]
-# mode = "upload"
+# [season]
 # auth_token = "your auth token"
 # prefix = "season"
-# # override global build section per-target if desired
-# [targets.season.build]
-#   features = ["seasonal-season-1"]
-
-# [targets.copy]
-# mode = "copy"
-# destination = "your copy destination"
-# prune = false
+# [season.build]
+#   features = ["my-crate-season-1-feature"]

--- a/screeps-defaults.toml
+++ b/screeps-defaults.toml
@@ -1,20 +1,37 @@
-default_deploy_mode = "upload"
-
-[upload]
-auth_token = "your auth token"
-branch = "default"
-# username = "your username or email"
-# password = "your password"
-# ptr = false
-# hostname = "screeps.com"
-# ssl = true
-# port = 443
-
-# [copy]
-# destination = "your copy destination"
-# prune = false
+default_deploy_target = "upload"
 
 # [build]
 # use absolute file path to get out of "target/"
 # ouptut_js_file = "main.js"
 # output_wasm_file = "compiled.wasm"
+# features = []
+
+[targets.upload]
+mode = "upload"
+# either auth_token or username and password required for upload
+auth_token = "your auth token"
+# username = "your username or email"
+# password = "your password"
+# branch = "default"
+# ptr = false
+# hostname = "screeps.com"
+# ssl = true
+# port = 443
+
+# [targets.ptr]
+# mode = "upload"
+# auth_token = "your auth token"
+# prefix = "ptr"
+
+# [targets.season]
+# mode = "upload"
+# auth_token = "your auth token"
+# prefix = "season"
+# # override global build section per-target if desired
+# [targets.season.build]
+#   features = ["seasonal-season-1"]
+
+# [targets.copy]
+# mode = "copy"
+# destination = "your copy destination"
+# prune = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -103,9 +103,9 @@ fn default_port() -> u16 {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(untagged)]
 pub enum Authentication {
-    AuthToken(String),
+    Token { auth_token: String },
     Basic { username: String, password: String },
 }
 

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -4,16 +4,16 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use failure::format_err;
 use log::*;
 
-use crate::config::Configuration;
+use crate::config::{Configuration, CopyConfiguration};
 
-pub fn copy<P: AsRef<Path>>(root: P, config: &Configuration) -> Result<(), failure::Error> {
+pub fn copy<P: AsRef<Path>>(
+    root: P,
+    config: &Configuration,
+    copy_config: &CopyConfiguration,
+) -> Result<(), failure::Error> {
     let root = root.as_ref();
-    let copy_config = config.copy.as_ref().ok_or_else(|| {
-        format_err!("must include [copy] section in configuration to deploy using copy")
-    })?;
 
     // join root here so relative directories are correct even if 'cargo screeps' is
     // run in sub-directory.

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -6,20 +6,19 @@ use std::{
 
 use log::*;
 
-use crate::config::{Configuration, CopyConfiguration};
-
 pub fn copy<P: AsRef<Path>>(
     root: P,
-    config: &Configuration,
-    copy_config: &CopyConfiguration,
+    destination: &PathBuf,
+    branch: &String,
+    prune: bool,
+    output_js_file: &PathBuf,
+    output_wasm_file: &PathBuf,
 ) -> Result<(), failure::Error> {
     let root = root.as_ref();
 
     // join root here so relative directories are correct even if 'cargo screeps' is
     // run in sub-directory.
-    let output_dir = root
-        .join(&copy_config.destination)
-        .join(&copy_config.branch);
+    let output_dir = root.join(&destination).join(&branch);
 
     fs::create_dir_all(&output_dir)?;
 
@@ -27,14 +26,14 @@ pub fn copy<P: AsRef<Path>>(
 
     let mut deployed: HashSet<PathBuf> = HashSet::new();
 
-    for filename in &[&config.build.output_js_file, &config.build.output_wasm_file] {
+    for filename in &[&output_js_file, &output_wasm_file] {
         let path = target_dir.join(filename);
         let output_path = output_dir.join(filename);
         fs::copy(&path, &output_path)?;
         deployed.insert(output_path);
     }
 
-    if copy_config.prune {
+    if prune {
         for entry in fs::read_dir(output_dir)? {
             let entry = entry?;
             let path = entry.path();

--- a/src/run.rs
+++ b/src/run.rs
@@ -170,7 +170,16 @@ fn run_upload(
     http_timeout: Option<u32>,
 ) -> Result<(), failure::Error> {
     info!("uploading...");
-    upload::upload(root, authentication, branch, hostname, ssl, port, prefix, http_timeout)?;
+    upload::upload(
+        root,
+        authentication,
+        branch,
+        hostname,
+        ssl,
+        port,
+        prefix,
+        http_timeout,
+    )?;
     info!("uploaded.");
 
     Ok(())

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fs, io::Read, path::Path};
+use std::{collections::HashMap, fs, io::Read, path::Path, time::Duration};
 
 use failure::{bail, ensure};
 use log::*;
@@ -46,7 +46,9 @@ pub fn upload(
         }
     }
 
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(300))
+        .build()?;
 
     let url = format!(
         "{}://{}:{}/{}",

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -103,7 +103,7 @@ fn authenticate(
     authentication: &Authentication,
 ) -> reqwest::RequestBuilder {
     match authentication {
-        Authentication::AuthToken(ref token) => request.header("X-Token", token.as_str()),
+        Authentication::Token { ref auth_token } => request.header("X-Token", auth_token.as_str()),
         Authentication::Basic {
             ref username,
             ref password,

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -1,16 +1,12 @@
 use std::{collections::HashMap, fs, io::Read, path::Path};
 
-use failure::{bail, ensure, format_err};
+use failure::{bail, ensure};
 use log::*;
 use serde::Serialize;
 
-use crate::config::{Authentication, Configuration};
+use crate::config::{Authentication, UploadConfiguration};
 
-pub fn upload(root: &Path, config: &Configuration) -> Result<(), failure::Error> {
-    let upload_config = config.upload.as_ref().ok_or_else(|| {
-        format_err!("must include [upload] section in configuration to deploy using upload")
-    })?;
-
+pub fn upload(root: &Path, upload_config: &UploadConfiguration) -> Result<(), failure::Error> {
     let target_dir = root.join("target");
 
     let mut files = HashMap::new();
@@ -49,10 +45,9 @@ pub fn upload(root: &Path, config: &Configuration) -> Result<(), failure::Error>
         if upload_config.ssl { "https" } else { "http" },
         upload_config.hostname,
         upload_config.port,
-        if upload_config.ptr {
-            "ptr/api/user/code"
-        } else {
-            "api/user/code"
+        match &upload_config.prefix {
+            Some(prefix) => format!("{}/api/user/code", prefix),
+            None => "api/user/code".to_string(),
         }
     );
 

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -49,10 +49,10 @@ pub fn upload(
 
     let client_builder = reqwest::Client::builder();
     let client = match http_timeout {
-        None =>         client_builder.build()?,
-        Some(value) =>  client_builder.timeout(
-                            Duration::from_secs(value as u64)
-                        ).build()?,
+        None => client_builder.build()?,
+        Some(value) => client_builder
+            .timeout(Duration::from_secs(value as u64))
+            .build()?,
     };
 
     let url = format!(


### PR DESCRIPTION
I made a ~~big~~ small breaking change to the screeps.toml 😓

My goal was to be able to deploy to different server environments with an arbitrary number of different configurations (MMO, PTR, seasonal, private servers), instead of just having `copy` and `upload` options in screeps.toml and needing to swap between configs for different servers/output directories.

- ~~`default_deploy_mode` switches to `default_deploy_target`, and each target (configured in a `[targets.foo]` section in toml) requires a `mode`, which is either `upload` or `copy`~~ Now supports arbitrary additional 'modes' in addition to `upload` and `copy` - `cargo screeps upload` / `cargo screeps copy` are now shortcuts for `cargo screeps deploy -m upload` / `cargo screeps deploy -m copy`
- `branch` is no longer required, and defaults to `default`
- BREAKING: `ptr` option removed for uploads, now using `prefix` which should be set to the API prefix path, `ptr` for PTR and `season` for seasonal
- BREAKING: port/ssl defaults changed to `443`/`true` at all times instead of SSL for `screeps.com` and plaintext for other hosts
- Global `build` options can be optionally overwritten by a `[mode.build]` section
- Crate features sets activated in the cargo-web build step can be configured in build configurations, allowing for conditionally compiled crate features which are only used on certain targets

Still todo if this seems like a decent approach:
- [x] changelog
- [x] readme
- [x] deserialize of `Authentication::Basic` variant not working quite right