### PR TITLE
Add path support to allow for cargo workspaces.

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -32,6 +32,7 @@ pub fn build(root: &Path, build_config: &BuildConfiguration) -> Result<(), failu
     };
 
     let options = BuildOptions {
+        path: build_config.path.clone(),
         target: Target::Nodejs,
         out_dir: "pkg".to_string(),
         out_name: Some(out_name.clone()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,8 @@ pub struct BuildConfiguration {
     #[merge(strategy = merge::vec::overwrite_empty)]
     #[serde(default)]
     pub extra_options: Vec<String>,
+    #[serde(default)]
+    pub path: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, Deserialize)]


### PR DESCRIPTION
This allows for a specific project in a cargo workspace to be used as the primary target for build/deploy to screeps.