### PR TITLE
Path support

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -47,7 +47,13 @@ pub fn build(root: &Path, build_config: &BuildConfiguration) -> Result<(), failu
 
     debug!("finished executing wasm-pack build");
 
-    let target_dir = root.join("pkg");
+    let target_dir = build_config
+        .path
+        .as_ref()
+        .map(|p| root.join(p))
+        .unwrap_or_else(|| root.into())
+        .join("pkg");
+
     let mut generated_js = None;
     for r in fs::read_dir(&target_dir)? {
         let entry = r?;

--- a/src/build.rs
+++ b/src/build.rs
@@ -32,6 +32,7 @@ pub fn build(root: &Path, build_config: &BuildConfiguration) -> Result<(), failu
     };
 
     let options = BuildOptions {
+        path: build_config.path.clone(),
         target: Target::Nodejs,
         out_dir: "pkg".to_string(),
         out_name: Some(out_name.clone()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,8 @@ pub struct BuildConfiguration {
     #[merge(strategy = merge::vec::overwrite_empty)]
     #[serde(default)]
     pub extra_options: Vec<String>,
+    #[serde(default)]
+    pub path: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -8,6 +8,7 @@ use log::*;
 
 pub fn copy<P: AsRef<Path>>(
     root: P,
+    build_path: &Option<PathBuf>,
     destination: &PathBuf,
     branch: &String,
     include_files: &Vec<PathBuf>,
@@ -24,7 +25,11 @@ pub fn copy<P: AsRef<Path>>(
     let mut deployed: HashSet<PathBuf> = HashSet::new();
 
     for target in include_files {
-        let target_dir = root.join(target);
+        let target_dir = build_path
+            .as_ref()
+            .map(|p| root.join(p))
+            .unwrap_or_else(|| root.into())
+            .join(target);
 
         for entry in fs::read_dir(target_dir)? {
             let entry = entry?;

--- a/src/run.rs
+++ b/src/run.rs
@@ -53,7 +53,7 @@ pub fn run() -> Result<(), failure::Error> {
                     } => {
                         config.build.merge(build);
                         run_build(&root, &config.build)?;
-                        run_copy(&root, &destination, &branch, &include_files, prune)?;
+                        run_copy(&root, &config.build.path, &destination, &branch, &include_files, prune)?;
                     }
                     ModeConfiguration::Upload {
                         authentication,
@@ -69,6 +69,7 @@ pub fn run() -> Result<(), failure::Error> {
                         run_build(&root, &config.build)?;
                         run_upload(
                             &root,
+                            &config.build.path,
                             &authentication,
                             &branch,
                             &include_files,
@@ -96,13 +97,14 @@ fn run_build(root: &Path, config: &BuildConfiguration) -> Result<(), failure::Er
 
 fn run_copy(
     root: &Path,
+    build_path: &Option<PathBuf>,
     destination: &PathBuf,
     branch: &String,
     include_files: &Vec<PathBuf>,
     prune: bool,
 ) -> Result<(), failure::Error> {
     info!("copying...");
-    copy::copy(root, destination, branch, include_files, prune)?;
+    copy::copy(root, build_path, destination, branch, include_files, prune)?;
     info!("copied.");
 
     Ok(())
@@ -110,6 +112,7 @@ fn run_copy(
 
 fn run_upload(
     root: &Path,
+    build_path: &Option<PathBuf>,
     authentication: &Authentication,
     branch: &String,
     include_files: &Vec<PathBuf>,
@@ -121,6 +124,7 @@ fn run_upload(
     info!("uploading...");
     upload::upload(
         root,
+        build_path,
         authentication,
         branch,
         include_files,

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -14,6 +14,7 @@ use crate::config::Authentication;
 
 pub fn upload(
     root: &Path,
+    build_path: &Option<PathBuf>,
     authentication: &Authentication,
     branch: &String,
     include_files: &Vec<PathBuf>,
@@ -25,7 +26,11 @@ pub fn upload(
     let mut files = HashMap::new();
 
     for target in include_files {
-        let target_dir = root.join(target);
+        let target_dir = build_path
+            .as_ref()
+            .map(|p| root.join(p))
+            .unwrap_or_else(|| root.into())
+            .join(target);
 
         for entry in fs::read_dir(target_dir)? {
             let entry = entry?;


### PR DESCRIPTION
Add proper sub-crate support to copy/upload behaviors. If a build path is specified, use that for discovering artifacts.