### PR TITLE
Changelog prep for 0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 Unreleased
 ==================
 
-- Added configuration for upload HTTP request timeout `http_timeout` (#26)
+
+0.4.0 (2022-09-08)
+==================
+
 - (Breaking) Remove `ptr` option from configuration, replaced with `prefix` which can be set to
   a desired API URL prefix - `prefix = "ptr"` replaces the functionality of `ptr = true`
 - (Breaking) The default `port` is now 443 and `ssl` now defaults to true (previous default was
   HTTPS for screeps.com and HTTP for other hosts)
+- Added configuration for upload HTTP request timeout `http_timeout` (#26)
 - `branch` option is no longer required, `"default"` is the default if none is configured
 - Options from the `[build]` section can be overridden for any individual mode in `[modename.build]`
 - `[build]` options now support specifying `features`, a list of crate features to be passed to


### PR DESCRIPTION
One last stdweb release with the modes stuff which'll be shared with bindgen, before we rip all of the stdweb support out for the next version 😈 