### PR TITLE
Add counting and logging info on how much of the code size limit an upload is using

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ==================
 
+- Add logging output showing the percentage of the code size limit being consumed when uploading.
+
 0.5.0 (2023-03-13)
 ==================
 

--- a/src/build/arena.rs
+++ b/src/build/arena.rs
@@ -92,14 +92,14 @@ pub fn build(root: &Path, build_config: &BuildConfiguration) -> Result<(), failu
     debug!("renaming wasm file");
 
     let generated_wasm_rename_to = generated_wasm.with_extension("wasm.bin");
-    fs::rename(&generated_wasm, &generated_wasm_rename_to)?;
+    fs::rename(&generated_wasm, generated_wasm_rename_to)?;
 
     debug!("processing js file");
 
     let generated_js_contents = fs::read_to_string(&generated_js)?;
 
     let generated_js_rename_to = generated_js.with_extension("jsorig");
-    fs::rename(&generated_js, &generated_js_rename_to)?;
+    fs::rename(&generated_js, generated_js_rename_to)?;
 
     let processed_js = process_js(&generated_js_contents)?;
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -30,6 +30,7 @@ fn app() -> clap::App<'static, 'static> {
                     clap::Arg::with_name("verbose")
                         .short("v")
                         .long("verbose")
+                        .help("Show more information in command output; use multiple times for additional output")
                         .multiple(true),
                 )
                 .arg(

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -79,7 +79,7 @@ pub fn upload(
             pct_consumed * 100.
         );
     } else {
-        debug!(
+        info!(
             "Files to upload consuming {:.2}MiB of 5MiB limit ({:.2}%)",
             mb_consumed,
             pct_consumed * 100.

--- a/src/upload.rs
+++ b/src/upload.rs
@@ -12,6 +12,8 @@ use serde::Serialize;
 
 use crate::config::Authentication;
 
+const CODE_SIZE_LIMIT: u32 = 5 * 1024 * 1024;
+
 pub fn upload(
     root: &Path,
     build_path: &Option<PathBuf>,
@@ -22,6 +24,7 @@ pub fn upload(
     http_timeout: Option<u32>,
 ) -> Result<(), failure::Error> {
     let mut files = HashMap::new();
+    let mut files_total_bytes = 0u32;
 
     for target in include_files {
         let target_dir = build_path
@@ -41,6 +44,7 @@ pub fn upload(
                         fs::File::open(&path)?.read_to_string(&mut buf)?;
                         buf
                     };
+                    files_total_bytes += data.chars().count() as u32;
                     serde_json::Value::String(data)
                 } else if extension == "wasm" {
                     let data = {
@@ -48,7 +52,8 @@ pub fn upload(
                         fs::File::open(&path)?.read_to_end(&mut buf)?;
                         buf
                     };
-                    let data = base64::encode(&data);
+                    let data = base64::encode(data);
+                    files_total_bytes += data.chars().count() as u32;
                     serde_json::json!({ "binary": data })
                 } else {
                     continue;
@@ -57,6 +62,28 @@ pub fn upload(
                 files.insert(name.to_string_lossy().into_owned(), contents);
             }
         }
+    }
+
+    let pct_consumed = files_total_bytes as f64 / CODE_SIZE_LIMIT as f64;
+    let mb_consumed = files_total_bytes as f64 / 1024. / 1024.;
+    if files_total_bytes > CODE_SIZE_LIMIT {
+        warn!(
+            "Files to upload over limit, failure expected! {:.2}MiB of 5MiB limit ({:.2}%)",
+            mb_consumed,
+            pct_consumed * 100.
+        );
+    } else if pct_consumed > 0.9 {
+        warn!(
+            "Files to upload near limit! {:.2}MiB of 5MiB limit ({:.2}%)",
+            mb_consumed,
+            pct_consumed * 100.
+        );
+    } else {
+        debug!(
+            "Files to upload consuming {:.2}MiB of 5MiB limit ({:.2}%)",
+            mb_consumed,
+            pct_consumed * 100.
+        );
     }
 
     let client_builder = reqwest::blocking::Client::builder();


### PR DESCRIPTION
Add some logging output about the size of code being uploaded; warning if >90% of the 5MiB limit (or over it), debug otherwise.

Add a little extra info to the verbose flag in the help output and clean up outstanding clippy complaints.