### PR TITLE
Fix small spelling mistake in CLI arguments

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -26,7 +26,7 @@ fn app() -> clap::App<'static, 'static> {
             clap::SubCommand::with_name("screeps")
                 .author("David Ross")
                 .version(clap::crate_version!())
-                .about("Builds WASM-targetting Rust code and deploys to Screeps game servers")
+                .about("Builds WASM-targeting Rust code and deploys to Screeps game servers")
                 .setting(AppSettings::ArgRequiredElseHelp)
                 .arg(
                     clap::Arg::with_name("verbose")


### PR DESCRIPTION
Cleaning up old branches and found this minor fix that's still relevant, merging it in :)