### PR TITLE
Fix crash when config path is specified on command line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ==========
 
+- Fix crash when specifying config file path on command line
+
 0.5.2 (2024-01-15)
 ==================
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -37,7 +37,8 @@ fn app() -> clap::Command {
                         .short('c')
                         .long("config")
                         .num_args(1)
-                        .value_name("CONFIG_FILE"),
+                        .value_name("CONFIG_FILE")
+                        .value_parser(clap::value_parser!(PathBuf)),
                 )
                 .subcommand(
                     clap::Command::new("build")


### PR DESCRIPTION
Fixes #47 