### PR TITLE
Added ability for prune to remove subdirectories as well as files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Unreleased
 ==========
 
 - Fix crash when specifying config file path on command line
+- Updated `prune` option to delete subdirectories to fix deploying for Screeps: Arena
 
 0.5.2 (2024-01-15)
 ==================

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -56,7 +56,12 @@ pub fn copy<P: AsRef<Path>>(
 
             if !deployed.contains(&path) {
                 info!("pruning: removing {}", path.display());
-                fs::remove_file(path)?;
+
+                if path.is_dir() {
+                    fs::remove_dir_all(&path)?;
+                } else {
+                    fs::remove_file(&path)?;
+                }
             }
         }
     }


### PR DESCRIPTION
When using the `prune = true` option, the copy command would only delete files in the topmost branch directory. This PR allows prune to also remove any subdirectories. 

I believe this resolves #39.