### PR TITLE
Update cargo dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,4 @@ serde_ignored = "0.1"
 serde_json = "1"
 structopt = "0.3"
 toml = "1"
-wasm-pack = { version = "0.12", default-features = false }
+wasm-pack = { version = "0.15", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ description = "Build tool for deploying Rust WASM code to Screeps game servers"
 anyhow = "1"
 base64 = "0.22"
 clap = { version = "4", features = ["cargo"] }
-fern = "0.6"
+fern = "0.7"
 log = "0.4"
 merge = "0.1"
 pathdiff = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ base64 = "0.22"
 clap = { version = "4", features = ["cargo"] }
 fern = "0.7"
 log = "0.4"
-merge = "0.1"
+merge = "0.2"
 pathdiff = "0.2"
 regex = "1.7"
 reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ log = "0.4"
 merge = "0.2"
 pathdiff = "0.2"
 regex = "1.7"
-reqwest = { version = "0.11", default-features = false, features = ["blocking", "json", "rustls-tls"]}
+reqwest = { version = "0.13", default-features = false, features = ["blocking", "json", "rustls"]}
 serde = { version = "1", features = ["derive"] }
 serde_ignored = "0.1"
 serde_json = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ description = "Build tool for deploying Rust WASM code to Screeps game servers"
 
 [dependencies]
 anyhow = "1"
-base64 = "0.21"
+base64 = "0.22"
 clap = { version = "4", features = ["cargo"] }
 fern = "0.6"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,5 +32,5 @@ serde = { version = "1", features = ["derive"] }
 serde_ignored = "0.1"
 serde_json = "1"
 structopt = "0.3"
-toml = "0.8"
+toml = "1"
 wasm-pack = { version = "0.12", default-features = false }

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,15 +26,19 @@ pub enum BuildMode {
 
 #[derive(Clone, Debug, Deserialize, Default, Merge)]
 pub struct BuildConfiguration {
+    #[merge(strategy=merge::option::overwrite_none)]
     #[serde(default)]
     pub build_profile: Option<BuildProfile>,
+    #[merge(strategy=merge::option::overwrite_none)]
     #[serde(default)]
     pub build_mode: Option<BuildMode>,
+    #[merge(strategy=merge::option::overwrite_none)]
     #[serde(default)]
     pub out_name: Option<String>,
     #[merge(strategy = merge::vec::prepend)]
     #[serde(default)]
     pub extra_options: Vec<String>,
+    #[merge(strategy=merge::option::overwrite_none)]
     #[serde(default)]
     pub path: Option<PathBuf>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -141,7 +141,7 @@ impl Configuration {
         let mut unused_paths = BTreeSet::new();
 
         let config: Configuration =
-            serde_ignored::deserialize(toml::Deserializer::new(&config_str), |unused_path| {
+            serde_ignored::deserialize(toml::Deserializer::parse(&config_str)?, |unused_path| {
                 unused_paths.insert(unused_path.to_string());
             })
             .context("deserializing config")?;


### PR DESCRIPTION
This updates all cargo dependencies to current versions as several were out of date as seen here: https://deps.rs/repo/github/rustyscreeps/cargo-screeps
